### PR TITLE
Add Linux/ARM64 support to gradle-info-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'com.netflix.nebula:nebula-gradle-interop:latest.release'
     implementation 'com.netflix.nebula:gradle-contacts-plugin:latest.release'
     implementation 'org.eclipse.jgit:org.eclipse.jgit:5.7.0.202003110725-r'
-    implementation 'org.tmatesoft.svnkit:svnkit:1.8.12'
+    implementation 'org.tmatesoft.svnkit:svnkit:1.10.3'
     implementation 'net.java.dev.jna:jna-platform:5.7.0'
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
     testImplementation ('org.ajoberstar.grgit:grgit-core:4.0.2') {

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -31,4 +31,5 @@ org.jetbrains.kotlin:kotlin-stdlib:1.3.50
 org.jetbrains:annotations:13.0
 org.slf4j:slf4j-api:1.7.2
 org.tmatesoft.sqljet:sqljet:1.1.10
-org.tmatesoft.svnkit:svnkit:1.8.12
+org.tmatesoft.svnkit:svnkit:1.10.3
+org.lz4:lz4-java:1.4.1

--- a/gradle/dependency-locks/integTestCompileClasspath.lockfile
+++ b/gradle/dependency-locks/integTestCompileClasspath.lockfile
@@ -38,4 +38,5 @@ org.jetbrains:annotations:13.0
 org.slf4j:slf4j-api:1.7.2
 org.spockframework:spock-core:1.3-groovy-2.4
 org.tmatesoft.sqljet:sqljet:1.1.10
-org.tmatesoft.svnkit:svnkit:1.8.12
+org.tmatesoft.svnkit:svnkit:1.10.3
+org.lz4:lz4-java:1.4.1

--- a/gradle/dependency-locks/integTestRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/integTestRuntimeClasspath.lockfile
@@ -40,4 +40,5 @@ org.objenesis:objenesis:2.4
 org.slf4j:slf4j-api:1.7.2
 org.spockframework:spock-core:1.3-groovy-2.4
 org.tmatesoft.sqljet:sqljet:1.1.10
-org.tmatesoft.svnkit:svnkit:1.8.12
+org.tmatesoft.svnkit:svnkit:1.10.3
+org.lz4:lz4-java:1.4.1

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -31,4 +31,5 @@ org.jetbrains.kotlin:kotlin-stdlib:1.3.50
 org.jetbrains:annotations:13.0
 org.slf4j:slf4j-api:1.7.2
 org.tmatesoft.sqljet:sqljet:1.1.10
-org.tmatesoft.svnkit:svnkit:1.8.12
+org.tmatesoft.svnkit:svnkit:1.10.3
+org.lz4:lz4-java:1.4.1

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -38,4 +38,5 @@ org.jetbrains:annotations:13.0
 org.slf4j:slf4j-api:1.7.2
 org.spockframework:spock-core:1.3-groovy-2.4
 org.tmatesoft.sqljet:sqljet:1.1.10
-org.tmatesoft.svnkit:svnkit:1.8.12
+org.tmatesoft.svnkit:svnkit:1.10.3
+org.lz4:lz4-java:1.4.1

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -40,4 +40,5 @@ org.objenesis:objenesis:2.4
 org.slf4j:slf4j-api:1.7.2
 org.spockframework:spock-core:1.3-groovy-2.4
 org.tmatesoft.sqljet:sqljet:1.1.10
-org.tmatesoft.svnkit:svnkit:1.8.12
+org.tmatesoft.svnkit:svnkit:1.10.3
+org.lz4:lz4-java:1.4.1


### PR DESCRIPTION
**Hi**

**Package Owner:** Rahul Aggarwal

**PR change Details:**

**1. Patch Details:** 

- Updated svnkit version to '1.10.3' and added "org.lz4:lz4-java:1.4.1" dependency in the lockfiles, to support new version of svnkit.

- Following files have been modified:

1. build.gradle
2. gradle/dependency-locks/compileClasspath.lockfile
3. gradle/dependency-locks/integTestCompileClasspath.lockfile
4. gradle/dependency-locks/integTestRuntimeClasspath.lockfile
5. gradle/dependency-locks/runtimeClasspath.lockfile
6. gradle/dependency-locks/testCompileClasspath.lockfile
7. gradle/dependency-locks/testRuntimeClasspath.lockfile


**2. Testing Detail:**

Set JAVA_HOME to jdk-8 and execute ./gradlew build in the root of this repo. Build is passing on both the platforms after adding changes.

**3. PR Description:** Here is my commit message :

Updated svnkit version to '1.10.3' and added "org.lz4:lz4-java:1.4.1" dependency in the lockfiles, to support new version of svnkit.

Signed-off-by: odidev <odidev@puresoftware.com>

**4. Reviewer:** Pruthvi Teja Reddy 

**Thanks
Rahul Aggarwal**